### PR TITLE
Remove txindex=1

### DIFF
--- a/03.Configurazione_iniziale_dell'Hardware.md
+++ b/03.Configurazione_iniziale_dell'Hardware.md
@@ -89,12 +89,10 @@ Avviate il programma  `bitcoin-qt.exe` nella directory "O:\Bitcoin", anche proce
 
 ![Bitcoin Core directory selection](images/3_03BitcoinBlockchainFolder.PNG)
 
-:warning: **IMPORTANTE: Il prossimo step è fondamentale. Senza `txindex=1`la vostra Bitcoin blockchain sarà inutile!** :warning:  
 
-Bitcoin Core inizierà immediatamente a sincronizzare la blockchain , ma dovremo inserire un settaggio nel file “bitcoin.conf” in modo che il software scarichi l'intera blockchain e non solo le transazioni effettivamente usate dal nostro wallet. Dal menù di Bitcoin Core quindi selezionate `Impostazioni / Opzioni` e selezionate il pulsante `Apri il file di configurazione`. Inserite la seguente riga di comando:
-```
-txindex=1
-```
+Bitcoin Core inizierà immediatamente a sincronizzare la blockchain.
+
+
 Se il vostro computer ha molta memoria, inoltre potete aumentare la dimensione del database tenuto nella memoria cache aggiungendo la seguente riga di comando(specificando l'ammontare in megabytes di memoria da usare, a seconda della configurazione del vostro PC, il default è `dbcache=300`):
 
 ```
@@ -108,7 +106,7 @@ Salvate e chiudete il file di testo, uscite da Bitcoin Core usando `File` / `Exi
 ![Finalmente Stiamo Scaricando](images/005.ArmateviDiSanaPazienza.JPG)
 
 
-Lasciamolo lavorare in pace: saranno necessari diversi giorni perché il download della blockchain sia completato. 
+Lasciamolo lavorare in pace: a seconda della velocità della vostra connessione di rete e delle caratteristiche hardware della vostra workstation (RAM in primis) saranno necessarie dalle 12 ore a diversi giorni perché il download e la verifica della blockchain siano completati. 
 Nella finestra riportata nell'immagine potremo avere una preview del progresso della sincronizzazione, per un maggior dettaglio, aprire la finestra di debug tramite `Aiuto` / `Finestra di debug`: qui potremo tenere sotto controllo le connessioni ai peer della rete Bitcoin, il traffico generato per il download della blockchain ed altre informazioni. 
 
 

--- a/07.Bitcoin.md
+++ b/07.Bitcoin.md
@@ -100,7 +100,6 @@ testnet=1
 # Opzioni Bitcoind
 server=1
 daemon=1
-txindex=1
 
 # Impostazioni di connessione
 rpcuser=NodoBitcoin


### PR DESCRIPTION
Txindex=1 è un’opzione di Bitcoin Core che indica al nodo di creare un indice supplementare di tutte le transazioni bitcoin, non necessariamente legate gerarchicamente alle proprie chiavi private, permettendogli quindi di ottenere i dati di qualsiasi transazione mai avvenuta.
Sebbene quindi non fosse strettamente necessario per avere un full node funzionante, era strumentale all’utilizzo di LND, oltre che per poter fare analisi si sorta sulla blockchain stessa. 
Parallelamente , si può avere un full bitcoin node pruned (attivando il parametro prune=N, con N<>0)ovvero eliminando dalla blockchain tutte le transazioni che non contribuiscano più all’ UTXO attuale.  Ovviamente in questo modo si avrebbe un full node perfettamente funzionante, ma non in grado di poter garantire ai peers della rete bitcoin il download della blockchain originale, essendo questa priva di tutta la parte “storica”. 
Entrambe le opzioni erano obbligatorie (txindex attivato e pruning disattivato) per poter gestire un nodo LND. LND non è però più dipendente da txindex dalla versione 0.5, mentre ancora è sconsigliato il pruning in quanto è pericoloso eliminare una parte della blockchain che potrebbe essere rilevante per i nostri canali. 

Txindex=1 è sempre stato un problema per i principianti, in quanto necessitando di una configurazione particolare , spesso la blockchain non era correttamente indicizzata, ed il RasPi non ha le risorse Hardware necessarie a re-indicizzare la blockchain in un tempo ragionevole (sono necessarie diverse settimane). 

Txindex=1 era ancora necessario per utilizzare un server Electrum,  in modo da interrogare il nostro nodo con un SPV client compatibile. ElectrumX tx index è difatti ancora necessario. È però ora disponibile *electrs*, un’implementazione alternativa del server di Electrum in Rust, ancora più leggera e non dipendente da txindex=1. 

Ricapitolando: 

- Se volete mettere in piedi un nuovo nodo txindex=1 non è più necessario. 
- Se avete attivato sul vostri Raspi  txindex=1, non è necessario disabilitarlo.
- Se non lo avete abilitato, ma volete attivarlo, dalla versione 0.17 di Bitcoin Core, potete farlo: bicoind creerà l’indice con un processo in background, continuando a funzionare (precedentemente non poteva funzionare se l'indice non era completato).
- Se lo avete abilitato, e volete disattivarlo, potete farlo ed il database delle transazioni non sarà cancellato, lasciandovi la possibilità di riattivarlo in un secondo tempo. 
